### PR TITLE
Add callback and query function documentation links

### DIFF
--- a/en/advanced-configuration.md
+++ b/en/advanced-configuration.md
@@ -55,6 +55,8 @@ operations.
 `LiteRecord` allows you to define callbacks to execute actions at specific points in a model's lifecycle. Want to
 validate data before saving or log audits after an operation? You can do that!
 
+For a detailed list of all available callbacks, check out the [callbacks documentation](callbacks.md).
+
 ### Validation Example with a Callback
 
 To validate a product before saving it, define a method called `_beforeSave`.
@@ -89,6 +91,9 @@ if (!$product->save()) {
 
 Need to implement advanced searches or pagination? `LiteRecord` has you covered with custom SQL queries to efficiently
 filter data.
+
+For a detailed list of all query functions with LiteRecord, check out the
+[filter documentation](retrieving-data.md#filter-function).
 
 ### Filter Example
 

--- a/es/advanced-configuration.md
+++ b/es/advanced-configuration.md
@@ -56,6 +56,9 @@ operaciones.
 `LiteRecord` te permite definir callbacks para ejecutar acciones en momentos específicos del ciclo de vida de un modelo.
 ¿Quieres validar datos antes de guardar o registrar auditorías después de una operación? ¡Puedes hacerlo!
 
+Para obtener una lista detallada de todas los callbacks disponibles, consulte la
+[documentación sobre callbacks](callbacks.md).
+
 ### Ejemplo de validación con un callback
 
 Para validar un producto antes de guardarlo, define un método llamado `_beforeSave`.
@@ -90,6 +93,9 @@ if (!$producto->save()) {
 
 ¿Necesitas implementar búsquedas avanzadas o paginación? `LiteRecord` te tiene cubierto con consultas SQL personalizadas
 para filtrar datos de manera eficiente.
+
+Para obtener una lista detallada de todas las funciones de consulta con LiteRecord, consulte la
+[documentación sobre la función filter](retrieving-data.md#función-filter).
 
 ### Ejemplo de filtro
 


### PR DESCRIPTION
This commit adds links to the existing advanced-configuration documentations in both English and Spanish. The links direct the user to detailed lists of available callbacks and query functions with LiteRecord.