### PR TITLE
Add Spanish resources page and update README

### DIFF
--- a/es/README.md
+++ b/es/README.md
@@ -49,3 +49,7 @@
 - [Clase `Paginator`](paginate-query-results.md#clase-paginator)
 - [Ejemplo Práctico](paginate-query-results.md#ejemplo-práctico)
 - [Conclusión](paginate-query-results.md#conclusión)
+
+## Recursos y referencias
+- [Comunidad y soporte](resources.md#comunidad-y-soporte)
+- [Glosario de términos](resources.md#glosario-de-términos)

--- a/es/resources.md
+++ b/es/resources.md
@@ -1,0 +1,85 @@
+# Recursos y Referencias
+
+## Comunidad y soporte
+
+La comunidad de KumbiaPHP es un recurso valioso para aprender, resolver problemas y obtener ideas para mejorar tu
+implementación. Aquí tienes varias formas de interactuar y obtener ayuda:
+
+### Chat en tiempo real
+
+Únete a los canales de chat para interactuar con desarrolladores en tiempo real. Aquí puedes hacer preguntas rápidas o
+ayudar a otros.
+
+- [Slack de KumbiaPHP](https://kumbiaphp.slack.com)
+
+### Foros oficiales
+
+La comunidad mantiene foros oficiales donde puedes hacer preguntas, compartir tus conocimientos o simplemente explorar
+soluciones a problemas comunes.
+
+- [Foro de KumbiaPHP](https://foro.kumbiaphp.com/)
+
+### GitHub
+
+La plataforma GitHub ofrece una forma directa de contribuir a los proyectos oficiales y realizar solicitudes de soporte.
+También es útil para reportar errores o sugerir mejoras.
+
+- [Repositorio del nuevo ActiveRecord](https://github.com/KumbiaPHP/ActiveRecord/)
+
+### Documentación
+
+Revisa la documentación oficial para comprender las funcionalidades, prácticas recomendadas y ejemplos útiles.
+
+- [Documentación del nuevo ActiveRecord](https://github.com/KumbiaPHP/ActiveRecord-Doc)
+
+## Glosario de términos
+
+Un glosario proporciona definiciones rápidas para términos clave relacionados con el uso del nuevo ActiveRecord en
+KumbiaPHP. ¡Vamos a desmitificar algunos de estos términos técnicos!
+
+### Active Record
+
+Patrón de diseño en el que una clase representa una tabla de base de datos, y cada instancia de esa clase es un registro
+en la tabla.
+
+### Callback
+
+Método que se llama en momentos específicos del ciclo de vida de un modelo, como antes o después de una operación CRUD.
+
+### CRUD
+
+Acrónimo de Crear, Leer, Actualizar y Eliminar, que son las operaciones básicas de manipulación de datos.
+
+### LiteRecord
+
+Implementación simplificada del patrón Active Record en el nuevo sistema de KumbiaPHP, que ofrece funciones básicas de
+un ORM.
+
+### ORM
+
+Mapeo Objeto-Relacional, un método que convierte datos tabulares de una base de datos en objetos en un lenguaje de
+programación.
+
+### Validación
+
+Proceso para garantizar que los datos cumplan con ciertas reglas antes de ser aceptados en la base de datos.
+
+### Paginación
+
+Técnica que permite dividir grandes conjuntos de datos en partes más manejables, mejorando así la experiencia del
+usuario y el rendimiento de la aplicación.
+
+### Transacción
+
+Secuencia de operaciones que se ejecutan como una única unidad lógica de trabajo, garantizando que todas las operaciones
+se completen correctamente antes de ser confirmadas.
+
+### Índice
+
+Estructura de datos que mejora la velocidad de recuperación de datos en una tabla de base de datos. Los índices se crean
+en columnas que se consultan frecuentemente.
+
+### Clave externa
+
+Restricción que asegura la integridad referencial entre dos tablas, permitiendo que los datos en una columna sean
+consistentes con los datos en otra tabla.


### PR DESCRIPTION
A new Spanish 'resources.md' page has been added, providing various resources and a glossary for Spanish speaking users. The Spanish version of README.md was also updated to include links to "Comunidad y Soporte" and "Glosario de Términos" sections from the added resources page.